### PR TITLE
8.0.11.4-SNAPSHOT

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
 
-    implementation 'com.instabug.library:instabug:8.0.11'
+    implementation 'com.instabug.library:instabug:8.0.11.4-SNAPSHOT'
     implementation 'io.reactivex.rxjava2:rxjava:2.2.2'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
 }

--- a/app/src/main/java/com/jdamcd/instabugrxissue/App.kt
+++ b/app/src/main/java/com/jdamcd/instabugrxissue/App.kt
@@ -1,8 +1,10 @@
 package com.jdamcd.instabugrxissue
 
 import android.app.Application
+import android.util.Log
 import com.instabug.library.invocation.InstabugInvocationEvent
 import com.instabug.library.Instabug
+import io.reactivex.plugins.RxJavaPlugins
 
 class App : Application() {
 
@@ -16,5 +18,15 @@ class App : Application() {
         Instabug.Builder(this, "48ad905e141bc665d064945f423aa414")
                 .setInvocationEvents(InstabugInvocationEvent.SHAKE)
                 .build()
+
+        Log.e("XXX", RxJavaPlugins.getErrorHandler()?.javaClass?.simpleName ?: "No RxJavaPlugins error handler")
+
+        /*
+         * With the 8.0.11.4-SNAPSHOT version, RxJava behaviour is not altered. No RxJavaPlugins error handler is set.
+         * However, the Instabug SDK now crashes internally from system onLowMemory() callbacks. Reproduction steps:
+         * 1. Open the app
+         * 2. Exit to the home screen
+         * 3. `adb shell am send-trim-memory com.jdamcd.instabugrxissue HIDDEN`
+         */
     }
 }

--- a/app/src/main/java/com/jdamcd/instabugrxissue/MainActivity.kt
+++ b/app/src/main/java/com/jdamcd/instabugrxissue/MainActivity.kt
@@ -6,7 +6,6 @@ import android.widget.Toast
 import io.reactivex.Single
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
-import java.lang.RuntimeException
 
 class MainActivity : AppCompatActivity() {
 
@@ -26,13 +25,7 @@ class MainActivity : AppCompatActivity() {
         return Single.just("result")
                 .subscribe({
                     toast("onSuccess: $it")
-                    doSomethingWrong()
-                    toast("This code never executes, but the app didn't halt, so we're left in a non-deterministic state")
                 }, { e -> toast("onError: ${e.message}") })
-    }
-
-    private fun doSomethingWrong() {
-        throw RuntimeException("This should crash the main thread but is silently swallowed")
     }
 
     override fun onPause() {

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,9 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots"
+        }
     }
 }
 


### PR DESCRIPTION
Fixes the RxJavaPlugins error handler issues, but crashes internally from system `onLowMemory()` callbacks.